### PR TITLE
Adding nativeEvents necessary for mouseEnter and mouseLeave

### DIFF
--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -16,6 +16,8 @@ JsObject _TestUtils = _getNestedJsObject(
 
 JsObject _Simulate = _TestUtils['Simulate'];
 
+JsObject _SimulateNative = _TestUtils['SimulateNative'];
+
 _getNestedJsObject(
     JsObject base, List<String> keys, [String errorIfNotFound='']) {
   JsObject object = base;
@@ -147,6 +149,20 @@ class Simulate {
 
   static void wheel(JsObject element, [Map eventData = const{}]) =>
       _Simulate.callMethod('wheel', [element, new JsObject.jsify(eventData)]);
+
+}
+
+/// Native event simulation interface.
+///
+/// Provides methods that allow for simulation of mouseEnter and mouseLeave
+
+class SimulateNative {
+
+  static void mouseOut(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseOut', [element, new JsObject.jsify(eventData)]);
+
+  static void mouseOver(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseOver', [element, new JsObject.jsify(eventData)]);
 
 }
 

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -61,7 +61,9 @@ void main() {
     test('mouseDown', () => testEvent(Simulate.mouseDown, 'mouseDown'));
     test('mouseMove', () => testEvent(Simulate.mouseMove, 'mouseMove'));
     test('mouseOut', () => testEvent(Simulate.mouseOut, 'mouseOut'));
+    test('mouseOut native', () => testEvent(SimulateNative.mouseOut, 'mouseOut'));
     test('mouseOver', () => testEvent(Simulate.mouseOver, 'mouseOver'));
+    test('mouseOver native', () => testEvent(SimulateNative.mouseOver, 'mouseOver'));
     test('mouseUp', () => testEvent(Simulate.mouseUp, 'mouseUp'));
     test('paste', () => testEvent(Simulate.paste, 'paste'));
     test('scroll', () => testEvent(Simulate.scroll, 'scroll'));


### PR DESCRIPTION
During testing of the wContextMenu it was discovered that it was necessary to simulate native events in order to initiate a mouseEnter or mouseLeave event.

In this work added the necessary events in order to create those events within the dart react test utils.

issue originally documented - http://stackoverflow.com/questions/24140773/could-not-simulate-mouseenter-event-using-react-test-utils

@matthewbalvanz-wf @jonasray-wf 
