### PR TITLE
Adding method to allow search for Id

### DIFF
--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -344,6 +344,20 @@ List scryRenderedDOMComponentsWithClass(JsObject tree, String className) {
 }
 
 /// Finds all instances of components in the rendered tree that are DOM
+/// components with an id matching id arguments value.
+List scryRenderedDOMComponentsWithId(JsObject tree, String id) {
+  dartTestFunction(window, component) {
+    if (component['props']['id'] == id) {
+      return true;
+    }
+  }
+
+  JsFunction jsTestFunction = new JsFunction.withThis(dartTestFunction);
+
+  return findAllInRenderedTree(tree, jsTestFunction);
+}
+
+/// Finds all instances of components in the rendered tree that are DOM
 /// components with the tag name matching tagName.
 JsObject scryRenderedDOMComponentsWithTag(JsObject tree, String tagName) {
   return _TestUtils.callMethod(

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -346,11 +346,7 @@ List scryRenderedDOMComponentsWithClass(JsObject tree, String className) {
 /// Finds all instances of components in the rendered tree that are DOM
 /// components with an id matching id arguments value.
 List scryRenderedDOMComponentsWithId(JsObject tree, String id) {
-  dartTestFunction(window, component) {
-    if (component['props']['id'] == id) {
-      return true;
-    }
-  }
+  dartTestFunction(window, component) => component['props']['id'] == id;
 
   JsFunction jsTestFunction = new JsFunction.withThis(dartTestFunction);
 

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -229,6 +229,22 @@ void main() {
     expect(results[1]['tagName'], equals('DIV'));
   });
 
+  test('scryRenderedDomComponentsWithId', () {
+    var idName = 'searchableId';
+
+    component = renderIntoDocument(div({}, [
+      div({'id': idName}),
+      div({'id': idName}),
+      span({})
+    ]));
+
+    var results = scryRenderedDOMComponentsWithId(component, idName);
+
+    expect(results.length, 2);
+    expect(results[0]['props']['id'], equals(idName));
+    expect(results[1]['props']['id'], equals(idName));
+  });
+
   test('scryRenderedDOMComponentsWithTag', () {
     component = renderIntoDocument(div({}, [div({}), div({}), span({})]));
 

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -229,20 +229,36 @@ void main() {
     expect(results[1]['tagName'], equals('DIV'));
   });
 
-  test('scryRenderedDomComponentsWithId', () {
-    var idName = 'searchableId';
+  group('scryRenderedDomComponentsWithId',(){
+    var matchingId = 'searchableId';
+    var mismatchedId = 'theWrongId';
 
-    component = renderIntoDocument(div({}, [
-      div({'id': idName}),
-      div({'id': idName}),
-      span({})
-    ]));
+    test('returns components with matching id', () {
+      component = renderIntoDocument(div({}, [
+        div({'id': matchingId}),
+        div({'id': matchingId}),
+        div({'id': mismatchedId}),
+        span({})
+      ]));
 
-    var results = scryRenderedDOMComponentsWithId(component, idName);
+      var results = scryRenderedDOMComponentsWithId(component, matchingId);
 
-    expect(results.length, 2);
-    expect(results[0]['props']['id'], equals(idName));
-    expect(results[1]['props']['id'], equals(idName));
+      expect(results.length, 2);
+      expect(results[0]['props']['id'], equals(matchingId));
+      expect(results[1]['props']['id'], equals(matchingId));
+    });
+
+    test('returns empty list when no matches detected', () {
+      component = renderIntoDocument(div({}, [
+        div({'id': mismatchedId}),
+        div({'id': mismatchedId}),
+        span({})
+      ]));
+
+      var results = scryRenderedDOMComponentsWithId(component, matchingId);
+
+      expect(results.isEmpty, isTrue);
+    });
   });
 
   test('scryRenderedDOMComponentsWithTag', () {


### PR DESCRIPTION
Internal Review
## Issue
- There is no way to search for elements by Id
## Changes

**Source:**
- Added method to allow for this type of search

**Tests:**
- Added corresponding test
## Areas of Regression
- n/a
## Testing
- Ensure that tests pass
## Code Review

@greglittlefield-wf
@tylersnavely-wf
@jonasray-wf
